### PR TITLE
Command line interface modifications

### DIFF
--- a/PETRreader.py
+++ b/PETRreader.py
@@ -62,7 +62,7 @@ class DateError(Exception):  # invalid date
 # ================== CONFIG FILE INPUT ================== #
 
 
-def parse_Config():
+def parse_Config(config_path):
     """
     Parse PETRglobals.ConfigFileName. The file should be ; the default is PETR_config.ini
     in the working directory but this can be changed using the -c option in the command
@@ -88,7 +88,7 @@ def parse_Config():
     parser = ConfigParser()
 #		logger.info('Found a config file in working directory')
 #	print "pc",PETRglobals.ConfigFileName
-    confdat = parser.read(PETRglobals.ConfigFileName)
+    confdat = parser.read(config_path)
     if len(confdat) == 0:
         print "\aError: Could not find the config file:", PETRglobals.ConfigFileName
         print "Terminating program"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ However, it now has almost all of the features of the TABARI coder.
 Documentation could also use a little work (really??) but is fairly complete, though 
 scattered in """...""" blocks throughout the program.
 
+##Running
+
+Currently, you can run PETRARCH using the following command:
+
+    python PETR.coder.py parse -i GigaWord.sample.PETR.txt -o test_output.txt
+
+There's also the option to specify a configuration file using the `-c <CONFIG
+FILE>` flag, but the program will default to using `PETR_config.ini`.
+
+You can get help with the program by running
+
+    python PETR.coder.py -h
+
 ##Unit tests
 
 Commits should always successfully complete 


### PR DESCRIPTION
Tweaking how the command line arguments are parsed. Making use of the `argparse` module within the Python stlib. Currently have two commands defined: `parse` and `validate`. This new setup will allow us to easily expand the command line interface in the future. 

Also modified a few things regarding how arguments are passed to functions, especially when it comes to parsing the config file. Future iterations will likely move to using a named tuple structure for the config arguments. 

**Note:** _The original program gave precedence to the input and output files defined in the config file. This iteration pretty much ignores those files defined in the config file and only considers the files defined by the command line interface._
