### PR TITLE
Potential fix for StanfordNLP link.

### DIFF
--- a/petrarch.properties
+++ b/petrarch.properties
@@ -1,0 +1,67 @@
+annotators = tokenize, ssplit, pos, lemma, parse
+# annotators = tokenize, ssplit, pos, lemma, ner, parse, dcoref, sentiment
+
+# A true-casing annotator is also available (see below)
+# annotators = tokenize, ssplit, pos, lemma, truecase
+
+# A simple regex NER annotator is also available
+# annotators = tokenize, ssplit, regexner
+
+#Use these as EOS punctuation and discard them from the actual sentence content
+#These are HTML tags that get expanded internally to correct syntax, e.g., from "p" to "<p>", "</p>" etc.
+#Will have no effect if the "cleanxml" annotator is used
+#ssplit.htmlBoundariesToDiscard = p,text
+
+#
+# None of these paths are necessary anymore: we load all models from the JAR file
+#
+
+#pos.model = /u/nlp/data/pos-tagger/wsj3t0-18-left3words/left3words-distsim-wsj-0-18.tagger
+## slightly better model but much slower:
+##pos.model = /u/nlp/data/pos-tagger/wsj3t0-18-bidirectional/bidirectional-distsim-wsj-0-18.tagger
+
+#ner.model.3class = /u/nlp/data/ner/goodClassifiers/all.3class.distsim.crf.ser.gz
+#ner.model.7class = /u/nlp/data/ner/goodClassifiers/muc.distsim.crf.ser.gz
+#ner.model.MISCclass = /u/nlp/data/ner/goodClassifiers/conll.distsim.crf.ser.gz
+
+#regexner.mapping = /u/nlp/data/TAC-KBP2010/sentence_extraction/type_map_clean
+#regexner.ignorecase = false
+
+#nfl.gazetteer = /scr/nlp/data/machine-reading/Machine_Reading_P1_Reading_Task_V2.0/data/SportsDomain/NFLScoring_UseCase/NFLgazetteer.txt
+#nfl.relation.model =  /scr/nlp/data/ldc/LDC2009E112/Machine_Reading_P1_NFL_Scoring_Training_Data_V1.2/models/nfl_relation_model.ser
+#nfl.entity.model =  /scr/nlp/data/ldc/LDC2009E112/Machine_Reading_P1_NFL_Scoring_Training_Data_V1.2/models/nfl_entity_model.ser
+#printable.relation.beam = 20
+
+#parser.model = /u/nlp/data/lexparser/englishPCFG.ser.gz
+
+#srl.verb.args=/u/kristina/srl/verbs.core_args
+#srl.model.cls=/u/nlp/data/srl/trainedModels/englishPCFG/cls/train.ann
+#srl.model.id=/u/nlp/data/srl/trainedModels/englishPCFG/id/train.ann
+
+#coref.model=/u/nlp/rte/resources/anno/coref/corefClassifierAll.March2009.ser.gz
+#coref.name.dir=/u/nlp/data/coref/
+#wordnet.dir=/u/nlp/data/wordnet/wordnet-3.0-prolog
+
+#dcoref.demonym = /scr/heeyoung/demonyms.txt
+#dcoref.animate = /scr/nlp/data/DekangLin-Animacy-Gender/Animacy/animate.unigrams.txt
+#dcoref.inanimate = /scr/nlp/data/DekangLin-Animacy-Gender/Animacy/inanimate.unigrams.txt
+#dcoref.male = /scr/nlp/data/Bergsma-Gender/male.unigrams.txt
+#dcoref.neutral = /scr/nlp/data/Bergsma-Gender/neutral.unigrams.txt
+#dcoref.female = /scr/nlp/data/Bergsma-Gender/female.unigrams.txt
+#dcoref.plural = /scr/nlp/data/Bergsma-Gender/plural.unigrams.txt
+#dcoref.singular = /scr/nlp/data/Bergsma-Gender/singular.unigrams.txt
+
+
+# This is the regular expression that describes which xml tags to keep
+# the text from.  In order to on off the xml removal, add cleanxml
+# to the list of annotators above after "tokenize".
+#clean.xmltags = .*
+# A set of tags which will force the end of a sentence.  HTML example:
+# you would not want to end on <i>, but you would want to end on <p>.
+# Once again, a regular expression.
+# (Blank means there are no sentence enders.)
+#clean.sentenceendingtags =
+# Whether or not to allow malformed xml
+# StanfordCoreNLP.properties
+#wordnet.dir=models/wordnet-3.0-prolog
+

--- a/petrarch/utilities.py
+++ b/petrarch/utilities.py
@@ -11,7 +11,9 @@ def stanford_parse(event_dict):
     #What is dead can never die...
     print "\nSetting up StanfordNLP. The program isn't dead. Promise.\n"
     logger.info('Setting up StanfordNLP')
-    core = corenlp.StanfordCoreNLP(PETRglobals.stanfordnlp)
+    core = corenlp.StanfordCoreNLP(PETRglobals.stanfordnlp,
+                                   properties=_get_config('petrarch.properties'),
+                                   memory='2g')
     for key in event_dict:
         for sent in event_dict[key]['sents']:
             print 'StanfordNLP parsing {}_{}...'.format(key, sent)


### PR DESCRIPTION
What this does:
- Drop the memory requirement from 3GB to 2GB. Hopefully less stressful on system resources.
- Remove some annotators from StanfordNLP to stop it from timing out when setting up.
